### PR TITLE
Add HTML pages for existing PDF documents

### DIFF
--- a/analysis-on-credit-default-risks-from-loans.html
+++ b/analysis-on-credit-default-risks-from-loans.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Analysis on Credit Default Risks from Loans</title>
+</head>
+<body>
+  <embed src="Analysis%20on%20Credit%20Default%20Risks%20from%20Loans%20.pdf" type="application/pdf" width="100%" height="1000px" />
+</body>
+</html>

--- a/playing-gomoku-like-a-human.html
+++ b/playing-gomoku-like-a-human.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Playing Gomoku Like A Human</title>
+</head>
+<body>
+  <embed src="Playing%20Gomoku%20Like%20A%20Human.pdf" type="application/pdf" width="100%" height="1000px" />
+</body>
+</html>

--- a/recommendation-system-on-million-song-dataset-using-alternating-least-square-algorithm.html
+++ b/recommendation-system-on-million-song-dataset-using-alternating-least-square-algorithm.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Recommendation System on Million Song Dataset using Alternating Least Square Algorithm</title>
+</head>
+<body>
+  <embed src="Recommendation%20System%20on%20Million%20Song%20Dataset%20using%20Alternating%20Least%20Square%20Algorithm.pdf" type="application/pdf" width="100%" height="1000px" />
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add HTML pages that embed each PDF so they can be viewed on the site

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894067573d8832f8bd468710ff56a62