### PR TITLE
Link PDF reports from home page

### DIFF
--- a/analysis-on-credit-default-risks-from-loans.html
+++ b/analysis-on-credit-default-risks-from-loans.html
@@ -5,6 +5,7 @@
   <title>Analysis on Credit Default Risks from Loans</title>
 </head>
 <body>
+  <p><a href="index.html">Back to Home</a></p>
   <embed src="Analysis%20on%20Credit%20Default%20Risks%20from%20Loans%20.pdf" type="application/pdf" width="100%" height="1000px" />
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -49,7 +49,14 @@
     <li>Music Recommendation System: Built and fine-tuned a recommendation system using Alternating Least Squares (ALS) on the Million Song Dataset with PySpark.</li>
     <li>Gomoku Cognitive Modeling: Reinforcement Learning, Monte Carlo Tree Search, Feature Engineering, Analytics.</li>
     <li>Human Comment Generator: Built a natural language generation model using GPT-2 and BERT, automating human-like comment creation for online platforms.</li>
-    <li>Default Risk Prediction: Engineered features and implemented classifiers (Naive Bayes, Logistic Regression, Random Forest, Decision Trees) to predict loan default risk.</li>
+  <li>Default Risk Prediction: Engineered features and implemented classifiers (Naive Bayes, Logistic Regression, Random Forest, Decision Trees) to predict loan default risk.</li>
+  </ul>
+
+  <h2>Reports and Papers</h2>
+  <ul>
+    <li><a href="analysis-on-credit-default-risks-from-loans.html">Analysis on Credit Default Risks from Loans</a></li>
+    <li><a href="playing-gomoku-like-a-human.html">Playing Gomoku Like A Human</a></li>
+    <li><a href="recommendation-system-on-million-song-dataset-using-alternating-least-square-algorithm.html">Recommendation System on Million Song Dataset using Alternating Least Square Algorithm</a></li>
   </ul>
 </body>
 </html>

--- a/playing-gomoku-like-a-human.html
+++ b/playing-gomoku-like-a-human.html
@@ -5,6 +5,7 @@
   <title>Playing Gomoku Like A Human</title>
 </head>
 <body>
+  <p><a href="index.html">Back to Home</a></p>
   <embed src="Playing%20Gomoku%20Like%20A%20Human.pdf" type="application/pdf" width="100%" height="1000px" />
 </body>
 </html>

--- a/recommendation-system-on-million-song-dataset-using-alternating-least-square-algorithm.html
+++ b/recommendation-system-on-million-song-dataset-using-alternating-least-square-algorithm.html
@@ -5,6 +5,7 @@
   <title>Recommendation System on Million Song Dataset using Alternating Least Square Algorithm</title>
 </head>
 <body>
+  <p><a href="index.html">Back to Home</a></p>
   <embed src="Recommendation%20System%20on%20Million%20Song%20Dataset%20using%20Alternating%20Least%20Square%20Algorithm.pdf" type="application/pdf" width="100%" height="1000px" />
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Link homepage to subpages that embed each project PDF
- Add simple navigation back to homepage on each PDF subpage

## Testing
- `npx -y htmlhint index.html analysis-on-credit-default-risks-from-loans.html playing-gomoku-like-a-human.html recommendation-system-on-million-song-dataset-using-alternating-least-square-algorithm.html`

------
https://chatgpt.com/codex/tasks/task_e_68940be22368832f853242b8115274d4